### PR TITLE
Add statement_id to statement table

### DIFF
--- a/src/pre_load.sql
+++ b/src/pre_load.sql
@@ -22,6 +22,7 @@ DROP TABLE IF EXISTS contract_stage;
 CREATE TABLE IF NOT EXISTS statement (
   id INT NOT NULL AUTO_INCREMENT,
   data json NOT NULL,
+  statement_id varchar(100) GENERATED ALWAYS AS (json_unquote(json_extract(data,'$._id.statementId'))) VIRTUAL,
   contract_id varchar(100) GENERATED ALWAYS AS (json_unquote(json_extract(data,'$.assessmentPeriod.contractId'))) VIRTUAL,
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Updated for the Claimant Api work so that the table is able to get the statementId field from the data that is passed through for the creation of it.